### PR TITLE
Fix Prev and Next links in footer

### DIFF
--- a/exampleSite/content/adding-content/index.md
+++ b/exampleSite/content/adding-content/index.md
@@ -1,6 +1,7 @@
 ---
 date: 2016-03-09T19:56:50+01:00
 title: Adding content
+weight: 20
 ---
 
 ## Hello world

--- a/exampleSite/content/getting-started/index.md
+++ b/exampleSite/content/getting-started/index.md
@@ -1,6 +1,7 @@
 ---
 date: 2016-03-09T00:11:02+01:00
 title: Getting started
+weight: 10
 ---
 
 ## Installation

--- a/exampleSite/content/index.md
+++ b/exampleSite/content/index.md
@@ -2,6 +2,7 @@
 date: 2016-03-08T21:07:13+01:00
 title: Material for Hugo
 type: index
+weight: 0
 ---
 
 ## Beautiful documentation

--- a/exampleSite/content/license/index.md
+++ b/exampleSite/content/license/index.md
@@ -1,6 +1,7 @@
 ---
 date: 2016-03-09T20:10:46+01:00
 title: License
+weight: 40
 ---
 
 Copyright (c) 2016 Digitalcraftsman <digitalcraftsman@protonmail.com><br>

--- a/exampleSite/content/roadmap/index.md
+++ b/exampleSite/content/roadmap/index.md
@@ -1,6 +1,7 @@
 ---
 date: 2016-03-09T20:08:11+01:00
 title: Roadmap
+weight: 30
 ---
 
 Quo vadis? The port of the original [Material theme](https://github.com/squidfunk/mkdocs-material) has replicated nearly all of its features. A few are still missing but I've good news: the Hugo community is actively working on this issues. Maybe with the next release of Hugo we can abandon this list. Stay tuned.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,8 +2,8 @@
 {{ if .Prev | or .Next }}
 <nav class="pagination" aria-label="Footer">
   <div class="previous">
-  {{ if .Next }}
-      <a href="{{ .Next.Permalink }}" title="{{ .Next.Title }}">
+  {{ if .Prev }}
+      <a href="{{ .Prev.Permalink }}" title="{{ .Prev.Title }}">
         <span class="direction">
           Previous
         </span>
@@ -13,7 +13,7 @@
           </div>
           <div class="stretch">
             <div class="title">
-              {{ .Next.Title }}
+              {{ .Prev.Title }}
             </div>
           </div>
         </div>
@@ -22,15 +22,15 @@
   </div>
 
   <div class="next">
-  {{ if .Prev }}
-      <a href="{{ .Prev.Permalink }}" title="{{ .Prev.Title }}">
+  {{ if .Next }}
+      <a href="{{ .Next.Permalink }}" title="{{ .Next.Title }}">
         <span class="direction">
           Next
         </span>
         <div class="page">
           <div class="stretch">
             <div class="title">
-              {{ .Prev.Title }}
+              {{ .Next.Title }}
             </div>
           </div>
           <div class="button button-next" role="button" aria-label="Next">

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -4,6 +4,7 @@
 
 {{ $.Scratch.Set "currentMenuEntry" . }}
 <li>
+  {{ partial "nav_link" $currentNode }}  
   {{ if .HasChildren }}
   <li>
     {{ $currentURL := .URL }}
@@ -13,7 +14,6 @@
       <span class="section">{{ .Section | title }}</span>
       {{ end }}
     {{ end }}
-    
 
     <ul>
       {{ range .Children }}
@@ -22,8 +22,6 @@
       {{ end }}
     </ul>
   </li>
-  {{ else }}
-    {{ partial "nav_link" $currentNode }}  
   {{ end }}
 </li>
 {{ end }}


### PR DESCRIPTION
Also display section name if haschildren (refs #17)

Anyway:

* Giving each page a Weight seems painful, and impossible to maintain
  with big projects
* The menu needs to be fixec for sections with children, currently all
  sections are "open" (again, not suitable for large projects)