### PR TITLE
Remove tiny little space after ‘Material’ in the footer of pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -39,9 +39,7 @@
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>
 				using the
-				<a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">
-					Material
-				</a> theme.
+				<a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">Material</a> theme.
 			</aside>
 		</div>
 	</article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,7 +27,7 @@
 			<h1>{{ .Title }} {{ if .IsDraft }} (Draft){{ end }}</h1>
 
 			{{ .Content }}
-			
+
 			<aside class="copyright" role="note">
 				{{ with .Site.Params.copyright }}
 				&copy; {{ $.Now.Format "2006" }} {{ . }} &ndash;
@@ -35,9 +35,7 @@
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>
 				using the
-				<a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">
-					Material
-				</a> theme.
+				<a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">Material</a> theme.
 			</aside>
 
 			<footer class="footer">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,7 +29,7 @@
 
 				{{ .Content }}
 			{{ end }}
-			
+
 			<aside class="copyright" role="note">
 				{{ with .Site.Params.copyright }}
 				&copy; {{ $.Now.Format "2006" }} {{ . }} &ndash;
@@ -37,9 +37,7 @@
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>
 				using the
-				<a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">
-					Material
-				</a> theme.
+				<a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">Material</a> theme.
 			</aside>
 
 			<footer class="footer">


### PR DESCRIPTION
Before:-

<img width="201" alt="screen shot 2016-06-11 at 22 11 31" src="https://cloud.githubusercontent.com/assets/825088/15987493/e0e070bc-3021-11e6-96df-44d8d507c607.png">


After:-

<img width="206" alt="screen shot 2016-06-11 at 22 14 59" src="https://cloud.githubusercontent.com/assets/825088/15987496/fce09602-3021-11e6-8905-8b7aee45a402.png">
