### PR TITLE
Removed unwanted "##" prefix in the top-level nav links.

### DIFF
--- a/layouts/partials/nav_link.html
+++ b/layouts/partials/nav_link.html
@@ -2,7 +2,7 @@
 {{ $isCurrent := eq .Permalink ($currentMenuEntry.URL | absURL | printf "%s") }}
 
 
-<a {{ if $isCurrent }}class="current"{{ end }} title="{{ $currentMenuEntry.Name }}" href="{{ $currentMenuEntry.URL | relURL}}">##
+<a {{ if $isCurrent }}class="current"{{ end }} title="{{ $currentMenuEntry.Name }}" href="{{ $currentMenuEntry.URL | relURL}}">
 	{{ $currentMenuEntry.Pre }}
 	{{ $currentMenuEntry.Name }}
 </a>


### PR DESCRIPTION
A previous commit (https://github.com/digitalcraftsman/hugo-material-docs/commit/821d50791c5ed078ac8fa8eaa579b00bc24db596) introduced the "##" prefix for nav links but I believe that wasn't on purpose. This PR removes this prefix.