### PR TITLE
If a menu entry has a page, make it a link even for nested menus.

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -5,7 +5,18 @@
 {{ $.Scratch.Set "currentMenuEntry" . }}
 <li>
   {{ if .HasChildren }}
+
+    {{ $currentMenuEntry := $.Scratch.Get "currentMenuEntry" }}
+    {{ $.Scratch.Set "foundIndex" false }}
+    {{ range where $.Site.Pages ".URLPath.URL" "==" $currentMenuEntry.URL }}
+      {{ $.Scratch.Set "foundIndex" true }}
+    {{ end }}
+
+    {{ if $.Scratch.Get "foundIndex" }}
+    <span class="parent_section">{{ partial "nav_link" $currentNode }}</span>
+    {{ else }}
     <span class="section">{{ .Name | title }}</span>
+    {{ end }}
     <ul>
       {{ range .Children }}
         {{ $.Scratch.Set "currentMenuEntry" . }}


### PR DESCRIPTION
Currently, a nested menu has grey-and-nonclickable main menu entries in the nav section.  This patch allows a "landing page" for such top level menu entries even with nested sections.  This landing page could be the front matter of a book, for example (if each top menu entry is a book, and subsections are chapters in that book).

Hugo doesn't allow reverse lookup of urls easily, so it's a bit lame (iterating over $.Site.Pages and accessing the undocumented URLPath). Unfortunately, MenuEntry objects can not be extended either, so there is no simpler solution that I can see.

Example:

```
[[menu.main]]
        name   = "User's Manual"
        url    = "user"
        weight = 10

[[menu.main]]
        name   = "System Manual"
        url    = "system"
        weight = 20
```

And then files:

```
content/user/00-index.md
content/user/10-chapter1.md
content/user/20-chapter2.md
content/system/00-index.md
content/system/10-chapter1.md
content/system/20-chapter2.md
```

This would be the preambel of an index file (content/user/00-index.md):
```
---
title: User's Manual
url: user
weight: 0
---
```

The URL "user" here is matched against the URL in the menu entry.  If they are equal.

And this the preambel of a chapter:
```
---
title: Introduction
url: user/introduction
weight: 10
menu:
  main:
    parent: User's Manual
    identifier: Introduction
    weight: 10
---
```