### PR TITLE
footer navigation for nested sections

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -43,32 +43,3 @@
 </nav>
 {{ end }}
 {{ end }}
-
-{{ if .IsHome }}
-{{ if gt (len .Site.Pages) 2 }}
-<nav class="pagination" aria-label="Footer">
-  <div class="previous">
-  </div>
-
-  {{ $title := (index (.Site.Pages.ByDate) 1).Title  }}
-  {{ $permalink := (index (.Site.Pages.ByDate) 1).Permalink }}
-  <div class="next">
-      <a href="{{ $permalink }}" title="{{ $title }}">
-        <span class="direction">
-          Next
-        </span>
-        <div class="page">
-          <div class="stretch">
-            <div class="title">
-              {{ $title }}
-            </div>
-          </div>
-          <div class="button button-next" role="button" aria-label="Next">
-            <i class="icon icon-forward"></i>
-          </div>
-        </div>
-      </a>
-  </div>
-</nav>
-{{ end }}
-{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,9 @@
 {{ if .IsPage }}
-{{ if .Prev | or .Next }}
+{{ if .PrevInSection | or .NextInSection }}
 <nav class="pagination" aria-label="Footer">
   <div class="previous">
-  {{ if .Prev }}
-      <a href="{{ .Prev.Permalink }}" title="{{ .Prev.Title }}">
+  {{ if .NextInSection }}
+      <a href="{{ .NextInSection.Permalink }}" title="{{ .NextInSection.Title }}">
         <span class="direction">
           Previous
         </span>
@@ -13,7 +13,7 @@
           </div>
           <div class="stretch">
             <div class="title">
-              {{ .Prev.Title }}
+              {{ .NextInSection.Title }}
             </div>
           </div>
         </div>
@@ -22,15 +22,15 @@
   </div>
 
   <div class="next">
-  {{ if .Next }}
-      <a href="{{ .Next.Permalink }}" title="{{ .Next.Title }}">
+  {{ if .PrevInSection }}
+      <a href="{{ .PrevInSection.Permalink }}" title="{{ .PrevInSection.Title }}">
         <span class="direction">
           Next
         </span>
         <div class="page">
           <div class="stretch">
             <div class="title">
-              {{ .Next.Title }}
+              {{ .PrevInSection.Title }}
             </div>
           </div>
           <div class="button button-next" role="button" aria-label="Next">


### PR DESCRIPTION
Oh well. This probably needs to be a global configuration option.  In my case, I want to use top level sections for parts in a multivolume book, and subsections for chapters in the individual volumes.  Currently, the weights need to be globally unique and monotone across all sections and subsections for navigation to work as expected.

In my case, I prefer local weights within each book (among the subsections) and local weights for all menu entries.

This patch implements that.

First, it uses PrevInSection and NextInSection to link subsections together.  If you use index pages for the sections (as enabled in #42), and give them the weight 0, they are linked into the flow at the beginning.  Of course, all subsections should be in a book-specific directory.

The homepage footer has been removed.  It didn't work properly anyway, using publication date to find the next link.  Using subsections for the home page is not very useful, so there is no special support for that (I am not even sure how that would look like).

Unfortunately, this removes footers from the non-nested sections case entirely, and that's not proper. So, I think there should be a global configuration option to control this.

What do you think?
