### PR TITLE
Typo fix and link for exampleSite dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install with `git`:
     git clone https://github.com/digitalcraftsman/hugo-material-docs.git themes/hugo-material-docs
 
 
-Next, take a look in the `exampleSite` folder at. This directory contains an example config file and the content for the demo. It serves as an example setup for your documentation. 
+Next, take a look in the [`exampleSite` folder](https://github.com/digitalcraftsman/hugo-material-docs/tree/master/exampleSite). This directory contains an example config file and the content for the demo. It serves as an example setup for your documentation. 
 
 Copy at least the `config.toml` in the root directory of your website. Overwrite the existing config file if necessary. 
 


### PR DESCRIPTION
I noticed this typo and took the opportunity to turn it into a link to the source on GitHub.

Thanks for your work and consideration!